### PR TITLE
Increase password padding

### DIFF
--- a/v380/v380.cpp
+++ b/v380/v380.cpp
@@ -18,7 +18,7 @@ struct TCommandReq {
 			uint32_t deviceId;
 			char hostDateTime[32]; // optional - maybe related to unk1/2, on v380 pc this is a domain name
 			char username[32];
-			char password[32]; // consists of randomkey:password
+			char password[64]; // consists of randomkey:password
 		} login;
 		struct {
 			uint32_t deviceId;   // 4:  +292
@@ -126,7 +126,7 @@ void GeneratePassword(std::vector<uint8_t>& output, const std::string& password)
 	const char* staticKey = "macrovideo+*#!^@";
 
 	std::vector<uint8_t> paddedPassword;
-	size_t pad = AES_BLOCKLEN - (password.size() % AES_BLOCKLEN);
+	size_t pad = 3 * AES_BLOCKLEN - (password.size() % AES_BLOCKLEN);
 	paddedPassword.resize(password.size() + pad);
 	memcpy_s(paddedPassword.data(), paddedPassword.size(), password.c_str(), password.size());
 
@@ -363,17 +363,17 @@ int main(int argc, const char* argv[])
 			std::vector<uint8_t> pw;
 			GeneratePassword(pw, password);
 
-			buf.resize(256, 0);
+			buf.resize(520, 0);
 			TCommandReq* req = reinterpret_cast<TCommandReq*>(buf.data());
 			TLoginResp resp;
 
 			req->command = 1167;
 			req->u.login.deviceId = stoi(id);
 			req->u.login.unknown1 = 1022;
-			req->u.login.unknown2 = 2;
+			req->u.login.unknown2 = 31;
 			req->u.login.unknown3 = 1;
 			memcpy_s(req->u.login.username, 32, username.c_str(), username.size());
-			memcpy_s(req->u.login.password, 32, pw.data(), pw.size());
+			memcpy_s(req->u.login.password, 64, pw.data(), pw.size());
 
 			socketAuth.Send(buf);
 			socketAuth.Recv(buf, 256, 5000);


### PR DESCRIPTION
Use 64 bytes for encrypted passsword rather than 32, as required for my firmware Hw_AWT3610E_XHR_E_V1.0_WF_20231114.

Not ready for merge - it should probably be an option whether to use the old or new mechanism, and also I haven't yet proven that the stream data that comes out is usable.

Fixes #22 .